### PR TITLE
fix: don't double-wrap WebRTCError raised inside connect()

### DIFF
--- a/decart/realtime/webrtc_connection.py
+++ b/decart/realtime/webrtc_connection.py
@@ -62,6 +62,9 @@ class WebRTCConnection:
         self._local_track: Optional[MediaStreamTrack] = None
         self._model_name: Optional[str] = None
         self._connection_error: Optional[str] = None
+        # Per-connect() dedup: _handle_error and connect()'s except branches both
+        # may see the same error; whichever fires first flips this to True and the
+        # other skips. Reset at the top of every connect() call.
         self._on_error_fired: bool = False
 
     async def connect(

--- a/decart/realtime/webrtc_connection.py
+++ b/decart/realtime/webrtc_connection.py
@@ -62,6 +62,7 @@ class WebRTCConnection:
         self._local_track: Optional[MediaStreamTrack] = None
         self._model_name: Optional[str] = None
         self._connection_error: Optional[str] = None
+        self._on_error_fired: bool = False
 
     async def connect(
         self,
@@ -77,6 +78,7 @@ class WebRTCConnection:
             self._local_track = local_track
             self._model_name = model_name
             self._connection_error = None
+            self._on_error_fired = False
 
             await self._set_state("connecting")
 
@@ -118,15 +120,15 @@ class WebRTCConnection:
 
         except WebRTCError as e:
             await self._set_state("disconnected")
-            # _handle_error already emitted on_error when it set _connection_error;
-            # only direct-raise paths (e.g., ack timeouts) still need reporting.
-            if self._on_error and not self._connection_error:
+            if self._on_error and not self._on_error_fired:
+                self._on_error_fired = True
                 self._on_error(e)
             raise
         except Exception as e:
             logger.error(f"Connection failed: {e}")
             await self._set_state("disconnected")
-            if self._on_error:
+            if self._on_error and not self._on_error_fired:
+                self._on_error_fired = True
                 self._on_error(e)
             raise WebRTCError(str(e), cause=e)
 
@@ -401,6 +403,7 @@ class WebRTCConnection:
         self._resolve_pending_waits(message.error)
 
         if self._on_error:
+            self._on_error_fired = True
             self._on_error(error)
 
     def register_image_set_wait(self) -> tuple[asyncio.Event, dict]:

--- a/decart/realtime/webrtc_connection.py
+++ b/decart/realtime/webrtc_connection.py
@@ -116,8 +116,12 @@ class WebRTCConnection:
 
             raise TimeoutError("Connection timeout")
 
-        except WebRTCError:
+        except WebRTCError as e:
             await self._set_state("disconnected")
+            # _handle_error already emitted on_error when it set _connection_error;
+            # only direct-raise paths (e.g., ack timeouts) still need reporting.
+            if self._on_error and not self._connection_error:
+                self._on_error(e)
             raise
         except Exception as e:
             logger.error(f"Connection failed: {e}")

--- a/decart/realtime/webrtc_connection.py
+++ b/decart/realtime/webrtc_connection.py
@@ -122,6 +122,7 @@ class WebRTCConnection:
             raise TimeoutError("Connection timeout")
 
         except WebRTCError as e:
+            logger.error(f"Connection failed: {e}")
             await self._set_state("disconnected")
             if self._on_error and not self._on_error_fired:
                 self._on_error_fired = True

--- a/decart/realtime/webrtc_connection.py
+++ b/decart/realtime/webrtc_connection.py
@@ -116,6 +116,9 @@ class WebRTCConnection:
 
             raise TimeoutError("Connection timeout")
 
+        except WebRTCError:
+            await self._set_state("disconnected")
+            raise
         except Exception as e:
             logger.error(f"Connection failed: {e}")
             await self._set_state("disconnected")

--- a/tests/test_realtime_unit.py
+++ b/tests/test_realtime_unit.py
@@ -1408,3 +1408,53 @@ async def test_connect_does_not_double_wrap_webrtc_error():
         "on_error should not be invoked by the connect() exception handler for WebRTCError; "
         f"got {errors!r}"
     )
+
+
+@pytest.mark.asyncio
+async def test_connect_direct_raise_fires_on_error_once():
+    """Direct-raise WebRTCError paths (e.g. ack timeouts) must fire on_error exactly once."""
+    from decart.realtime.webrtc_connection import WebRTCConnection
+    from decart.errors import WebRTCError
+
+    errors: list[Exception] = []
+    connection = WebRTCConnection(on_error=lambda e: errors.append(e))
+
+    async def _raise_ack_timeout(prompt, timeout=15.0):
+        raise WebRTCError("Initial prompt acknowledgment timed out")
+
+    connection._send_initial_prompt_and_wait = _raise_ack_timeout  # type: ignore[assignment]
+    connection._setup_peer_connection = AsyncMock()  # type: ignore[assignment]
+    connection._create_and_send_offer = AsyncMock()  # type: ignore[assignment]
+
+    async def _noop_receive():
+        await asyncio.sleep(60)
+
+    connection._receive_messages = _noop_receive  # type: ignore[assignment]
+
+    fake_ws = MagicMock()
+    fake_ws.closed = False
+    fake_ws.close = AsyncMock()
+
+    mock_session = MagicMock()
+    mock_session.closed = False
+    mock_session.close = AsyncMock()
+    mock_session.ws_connect = AsyncMock(return_value=fake_ws)
+
+    with patch(
+        "decart.realtime.webrtc_connection.aiohttp.ClientSession",
+        return_value=mock_session,
+    ):
+        with pytest.raises(WebRTCError) as exc_info:
+            await connection.connect(
+                url="https://example.com/ws",
+                local_track=None,
+                timeout=10.0,
+                initial_prompt={"text": "hello", "enhance": True},
+            )
+
+    assert exc_info.value.message == "Initial prompt acknowledgment timed out"
+    assert not isinstance(exc_info.value.cause, WebRTCError)
+    assert len(errors) == 1, (
+        f"on_error should fire exactly once for direct-raise paths; got {errors!r}"
+    )
+    assert errors[0] is exc_info.value

--- a/tests/test_realtime_unit.py
+++ b/tests/test_realtime_unit.py
@@ -1354,3 +1354,57 @@ async def test_connect_raises_immediately_on_connection_error_subscribe_mode():
                 )
     finally:
         injector.cancel()
+
+
+@pytest.mark.asyncio
+async def test_connect_does_not_double_wrap_webrtc_error():
+    """WebRTCError raised inside connect() re-raises as-is — no nested cause, no duplicate on_error."""
+    from decart.realtime.webrtc_connection import WebRTCConnection
+    from decart.errors import WebRTCError
+
+    errors: list[Exception] = []
+    connection = WebRTCConnection(on_error=lambda e: errors.append(e))
+
+    connection._setup_peer_connection = AsyncMock()  # type: ignore[assignment]
+    connection._create_and_send_offer = AsyncMock()  # type: ignore[assignment]
+
+    async def _noop_receive():
+        await asyncio.sleep(60)
+
+    connection._receive_messages = _noop_receive  # type: ignore[assignment]
+
+    fake_ws = MagicMock()
+    fake_ws.closed = False
+    fake_ws.close = AsyncMock()
+
+    mock_session = MagicMock()
+    mock_session.closed = False
+    mock_session.close = AsyncMock()
+    mock_session.ws_connect = AsyncMock(return_value=fake_ws)
+
+    async def inject_error_soon():
+        await asyncio.sleep(0.15)
+        connection._connection_error = "Server at capacity. Please try again later."
+
+    injector = asyncio.create_task(inject_error_soon())
+
+    try:
+        with patch(
+            "decart.realtime.webrtc_connection.aiohttp.ClientSession",
+            return_value=mock_session,
+        ):
+            with pytest.raises(WebRTCError) as exc_info:
+                await connection.connect(
+                    url="https://example.com/ws",
+                    local_track=None,
+                    timeout=10.0,
+                )
+    finally:
+        injector.cancel()
+
+    assert exc_info.value.message == "Server at capacity. Please try again later."
+    assert not isinstance(exc_info.value.cause, WebRTCError)
+    assert [type(e).__name__ for e in errors] == [], (
+        "on_error should not be invoked by the connect() exception handler for WebRTCError; "
+        f"got {errors!r}"
+    )

--- a/tests/test_realtime_unit.py
+++ b/tests/test_realtime_unit.py
@@ -1384,7 +1384,11 @@ async def test_connect_does_not_double_wrap_webrtc_error():
 
     async def inject_error_soon():
         await asyncio.sleep(0.15)
+        # Simulate _handle_error having run: it sets _connection_error, fires
+        # on_error, and marks _on_error_fired so connect() doesn't double-fire.
         connection._connection_error = "Server at capacity. Please try again later."
+        errors.append(WebRTCError("Server at capacity. Please try again later."))
+        connection._on_error_fired = True
 
     injector = asyncio.create_task(inject_error_soon())
 
@@ -1404,9 +1408,9 @@ async def test_connect_does_not_double_wrap_webrtc_error():
 
     assert exc_info.value.message == "Server at capacity. Please try again later."
     assert not isinstance(exc_info.value.cause, WebRTCError)
-    assert [type(e).__name__ for e in errors] == [], (
-        "on_error should not be invoked by the connect() exception handler for WebRTCError; "
-        f"got {errors!r}"
+    assert len(errors) == 1, (
+        "connect()'s WebRTCError handler must not fire on_error again when _handle_error "
+        f"already did; got {errors!r}"
     )
 
 

--- a/tests/test_realtime_unit.py
+++ b/tests/test_realtime_unit.py
@@ -1458,7 +1458,7 @@ async def test_connect_direct_raise_fires_on_error_once():
 
     assert exc_info.value.message == "Initial prompt acknowledgment timed out"
     assert not isinstance(exc_info.value.cause, WebRTCError)
-    assert len(errors) == 1, (
-        f"on_error should fire exactly once for direct-raise paths; got {errors!r}"
-    )
+    assert (
+        len(errors) == 1
+    ), f"on_error should fire exactly once for direct-raise paths; got {errors!r}"
     assert errors[0] is exc_info.value


### PR DESCRIPTION
## Summary

Errors surfaced through `realtime.connect()` were being reported twice and with a redundant nested cause. When a `WebRTCError` was raised from inside `connect()` (e.g. a server capacity rejection, or an initial image/prompt failure), the outer `except Exception` handler re-wrapped it into another `WebRTCError` and emitted it through the `on_error` callback a second time — once from the original raise site, once from the except block.

Callers now see a single, unwrapped error; `on_error` fires once per failure. Follow-up to #47, addressing review feedback.

## Test plan

- [x] New regression test asserts no nested `cause` and no duplicate `on_error` invocation
- [x] Full realtime unit suite still passes (38/38)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized error-handling change with added unit coverage; main risk is subtly altering callback firing order/behavior on edge-case connection failures.
> 
> **Overview**
> Prevents `WebRTCConnection.connect()` from *double-wrapping* a `WebRTCError` (and from emitting `on_error` twice) by adding a per-`connect()` `_on_error_fired` guard and a dedicated `except WebRTCError` path that re-raises as-is.
> 
> Adds regression tests covering both a server-error/`_handle_error` race and direct `WebRTCError` raises (e.g., ack timeouts), asserting no nested `cause` and exactly one `on_error` callback invocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a40c2ad46c0cf70c685cddb7d09b8f6318ed316a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->