### PR TITLE
feat: remove retired Lucy model IDs

### DIFF
--- a/decart/models.py
+++ b/decart/models.py
@@ -8,7 +8,6 @@ from .types import FileInput, MotionTrajectoryInput
 RealTimeModels = Literal[
     # Canonical names
     "lucy",
-    "lucy-2",
     "lucy-2.1",
     "lucy-2.1-vton",
     "lucy-restyle",
@@ -22,13 +21,11 @@ RealTimeModels = Literal[
     "mirage",
     "mirage_v2",
     "lucy_v2v_720p_rt",
-    "lucy_2_rt",
     "live_avatar",
 ]
 VideoModels = Literal[
     # Canonical names
     "lucy-clip",
-    "lucy-2",
     "lucy-2.1",
     "lucy-2.1-vton",
     "lucy-restyle-2",
@@ -42,7 +39,6 @@ VideoModels = Literal[
     # Deprecated names
     "lucy-pro-v2v",
     "lucy-restyle-v2v",
-    "lucy-2-v2v",
 ]
 ImageModels = Literal[
     # Canonical names
@@ -59,12 +55,10 @@ MODEL_ALIASES: dict[str, str] = {
     "mirage": "lucy-restyle",
     "mirage_v2": "lucy-restyle-2",
     "lucy_v2v_720p_rt": "lucy",
-    "lucy_2_rt": "lucy-2",
     "live_avatar": "live-avatar",
     # Video aliases
     "lucy-pro-v2v": "lucy-clip",
     "lucy-restyle-v2v": "lucy-restyle-2",
-    "lucy-2-v2v": "lucy-2",
     # Image aliases
     "lucy-pro-i2i": "lucy-image-2",
 }
@@ -163,7 +157,7 @@ class VideoRestyleInput(DecartBaseModel):
 
 
 class VideoEdit2Input(DecartBaseModel):
-    """Input for lucy-2-v2v model.
+    """Input for Lucy 2.1 video editing models.
 
     Prompt is required but can be an empty string.
     Optional reference_image can also be provided.
@@ -199,14 +193,6 @@ _MODELS = {
             fps=25,
             width=1280,
             height=704,
-            input_schema=BaseModel,
-        ),
-        "lucy-2": ModelDefinition(
-            name="lucy-2",
-            url_path="/v1/stream",
-            fps=20,
-            width=1280,
-            height=720,
             input_schema=BaseModel,
         ),
         "lucy-2.1": ModelDefinition(
@@ -299,14 +285,6 @@ _MODELS = {
             height=704,
             input_schema=BaseModel,
         ),
-        "lucy_2_rt": ModelDefinition(
-            name="lucy_2_rt",
-            url_path="/v1/stream",
-            fps=20,
-            width=1280,
-            height=720,
-            input_schema=BaseModel,
-        ),
         "live_avatar": ModelDefinition(
             name="live_avatar",
             url_path="/v1/stream",
@@ -325,14 +303,6 @@ _MODELS = {
             width=1280,
             height=704,
             input_schema=VideoToVideoInput,
-        ),
-        "lucy-2": ModelDefinition(
-            name="lucy-2",
-            url_path="/v1/jobs/lucy-2",
-            fps=20,
-            width=1280,
-            height=720,
-            input_schema=VideoEdit2Input,
         ),
         "lucy-2.1": ModelDefinition(
             name="lucy-2.1",
@@ -424,14 +394,6 @@ _MODELS = {
             height=704,
             input_schema=VideoRestyleInput,
         ),
-        "lucy-2-v2v": ModelDefinition(
-            name="lucy-2-v2v",
-            url_path="/v1/jobs/lucy-2-v2v",
-            fps=20,
-            width=1280,
-            height=720,
-            input_schema=VideoEdit2Input,
-        ),
     },
     "image": {
         # Canonical names
@@ -483,7 +445,6 @@ class Models:
 
         Available models:
             - "lucy-clip" - Video-to-video
-            - "lucy-2" - Video editing with reference image support
             - "lucy-2.1" - Video editing (newer, higher quality)
             - "lucy-restyle-2" - Video restyling with prompt or reference image
             - "lucy-motion" - Image-to-motion-video

--- a/decart/tokens/client.py
+++ b/decart/tokens/client.py
@@ -28,7 +28,7 @@ class TokensClient:
         # With expiry, model restrictions, and constraints:
         token = await client.tokens.create(
             expires_in=120,
-            allowed_models=["lucy-2"],
+            allowed_models=["lucy-2.1"],
             constraints={"realtime": {"maxSessionDuration": 300}},
         )
         ```
@@ -70,7 +70,7 @@ class TokensClient:
             token = await client.tokens.create(
                 metadata={"role": "viewer"},
                 expires_in=120,
-                allowed_models=["lucy-2"],
+                allowed_models=["lucy-2.1"],
                 constraints={"realtime": {"maxSessionDuration": 300}},
             )
             ```

--- a/examples/realtime_synthetic.py
+++ b/examples/realtime_synthetic.py
@@ -73,7 +73,7 @@ async def main():
         print("Creating synthetic video track...")
         video_track = SyntheticVideoTrack()
 
-        model = models.realtime("lucy-2")
+        model = models.realtime("lucy-2.1")
         print(f"Using model: {model.name}")
         print(f"Model config - FPS: {model.fps}, Size: {model.width}x{model.height}")
 

--- a/playground/playground.py
+++ b/playground/playground.py
@@ -93,14 +93,13 @@ logger = logging.getLogger("playground")
 
 REALTIME_MODELS = [
     "lucy",
-    "lucy-2",
     "lucy-2.1",
     "lucy-2.1-vton",
     "lucy-restyle",
     "lucy-restyle-2",
     "live-avatar",
 ]
-CAMERA_MODELS = {"lucy", "lucy-2", "lucy-2.1", "lucy-2.1-vton", "lucy-restyle", "lucy-restyle-2"}
+CAMERA_MODELS = {"lucy", "lucy-2.1", "lucy-2.1-vton", "lucy-restyle", "lucy-restyle-2"}
 AVATAR_MODELS = {"live-avatar"}
 
 BANNER = """
@@ -188,7 +187,7 @@ Examples:
   %(prog)s --model lucy-restyle-2 --prompt "Anime style"
   %(prog)s --model live-avatar --image avatar.png
   %(prog)s --model live-avatar --image avatar.png --audio speech.mp3
-  %(prog)s --model lucy-2 --image ref.png --prompt "Lego World"
+  %(prog)s --model lucy-2.1 --image ref.png --prompt "Lego World"
 """,
     )
     p.add_argument("--model", "-m", choices=REALTIME_MODELS, help="Model name")
@@ -209,7 +208,7 @@ def select_model_interactive() -> str:
         note = ""
         if name in AVATAR_MODELS:
             note = " (requires --image)"
-        elif name in ("lucy-2", "lucy-2.1", "lucy-2.1-vton", "lucy-restyle-2"):
+        elif name in ("lucy-2.1", "lucy-2.1-vton", "lucy-restyle-2"):
             note = " (supports reference image)"
         print(f"  {i}. {name}{note}")
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -229,23 +229,3 @@ def test_latest_aliases_no_deprecation_warning() -> None:
 def test_invalid_model() -> None:
     with pytest.raises(DecartSDKError):
         models.video("invalid-model")
-
-
-def test_retired_models_are_not_available() -> None:
-    retired_realtime_models = ["lucy-2", "lucy_2_rt"]
-    retired_video_models = [
-        "lucy-2",
-        "lucy-2-v2v",
-        "lucy-fast-v2v",
-        "lucy-dev-v2v",
-        "lucy-dev-i2v",
-        "lucy-pro-i2v",
-    ]
-
-    for model in retired_realtime_models:
-        with pytest.raises(DecartSDKError):
-            models.realtime(model)  # type: ignore[arg-type]
-
-    for model in retired_video_models:
-        with pytest.raises(DecartSDKError):
-            models.video(model)  # type: ignore[arg-type]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -24,12 +24,6 @@ def test_canonical_realtime_models() -> None:
     assert model.width == 1280
     assert model.height == 704
 
-    model = models.realtime("lucy-2")
-    assert model.name == "lucy-2"
-    assert model.fps == 20
-    assert model.width == 1280
-    assert model.height == 720
-
     model = models.realtime("lucy-2.1")
     assert model.name == "lucy-2.1"
     assert model.fps == 20
@@ -84,13 +78,6 @@ def test_canonical_video_models() -> None:
     assert model.name == "lucy-clip"
     assert model.url_path == "/v1/jobs/lucy-clip"
 
-    model = models.video("lucy-2")
-    assert model.name == "lucy-2"
-    assert model.url_path == "/v1/jobs/lucy-2"
-    assert model.fps == 20
-    assert model.width == 1280
-    assert model.height == 720
-
     model = models.video("lucy-2.1")
     assert model.name == "lucy-2.1"
     assert model.url_path == "/v1/jobs/lucy-2.1"
@@ -132,15 +119,6 @@ def test_deprecated_video_models() -> None:
         assert model.name == "lucy-restyle-v2v"
         assert len(w) == 1
         assert "lucy-restyle-2" in str(w[0].message)
-
-    _warned_aliases.clear()
-
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        model = models.video("lucy-2-v2v")
-        assert model.name == "lucy-2-v2v"
-        assert len(w) == 1
-        assert '"lucy-2"' in str(w[0].message)
 
 
 def test_canonical_image_models() -> None:
@@ -251,3 +229,23 @@ def test_latest_aliases_no_deprecation_warning() -> None:
 def test_invalid_model() -> None:
     with pytest.raises(DecartSDKError):
         models.video("invalid-model")
+
+
+def test_retired_models_are_not_available() -> None:
+    retired_realtime_models = ["lucy-2", "lucy_2_rt"]
+    retired_video_models = [
+        "lucy-2",
+        "lucy-2-v2v",
+        "lucy-fast-v2v",
+        "lucy-dev-v2v",
+        "lucy-dev-i2v",
+        "lucy-pro-i2v",
+    ]
+
+    for model in retired_realtime_models:
+        with pytest.raises(DecartSDKError):
+            models.realtime(model)  # type: ignore[arg-type]
+
+    for model in retired_video_models:
+        with pytest.raises(DecartSDKError):
+            models.video(model)  # type: ignore[arg-type]

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -269,19 +269,19 @@ async def test_queue_includes_user_agent_header() -> None:
         assert headers["User-Agent"].startswith("decart-python-sdk/")
 
 
-# Tests for lucy-2
+# Tests for lucy-2.1
 
 
 @pytest.mark.asyncio
-async def test_queue_lucy2_v2v_with_prompt() -> None:
+async def test_queue_lucy21_v2v_with_prompt() -> None:
     client = DecartClient(api_key="test-key")
 
     with patch("decart.queue.client.submit_job") as mock_submit:
-        mock_submit.return_value = MagicMock(job_id="job-lucy2", status="pending")
+        mock_submit.return_value = MagicMock(job_id="job-lucy21", status="pending")
 
         job = await client.queue.submit(
             {
-                "model": models.video("lucy-2"),
+                "model": models.video("lucy-2.1"),
                 "prompt": "Restyle the scene with softer contrast and warmer highlights",
                 "data": b"fake video data",
                 "enhance_prompt": True,
@@ -289,42 +289,42 @@ async def test_queue_lucy2_v2v_with_prompt() -> None:
             }
         )
 
-        assert job.job_id == "job-lucy2"
+        assert job.job_id == "job-lucy21"
         assert job.status == "pending"
         mock_submit.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_queue_lucy2_v2v_with_empty_prompt_and_reference_image() -> None:
+async def test_queue_lucy21_v2v_with_empty_prompt_and_reference_image() -> None:
     client = DecartClient(api_key="test-key")
 
     with patch("decart.queue.client.submit_job") as mock_submit:
-        mock_submit.return_value = MagicMock(job_id="job-lucy2-ref", status="pending")
+        mock_submit.return_value = MagicMock(job_id="job-lucy21-ref", status="pending")
 
         job = await client.queue.submit(
             {
-                "model": models.video("lucy-2"),
+                "model": models.video("lucy-2.1"),
                 "prompt": "",
                 "reference_image": b"fake image data",
                 "data": b"fake video data",
             }
         )
 
-        assert job.job_id == "job-lucy2-ref"
+        assert job.job_id == "job-lucy21-ref"
         assert job.status == "pending"
         mock_submit.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_queue_lucy2_v2v_with_both_prompt_and_reference_image() -> None:
+async def test_queue_lucy21_v2v_with_both_prompt_and_reference_image() -> None:
     client = DecartClient(api_key="test-key")
 
     with patch("decart.queue.client.submit_job") as mock_submit:
-        mock_submit.return_value = MagicMock(job_id="job-lucy2-both", status="pending")
+        mock_submit.return_value = MagicMock(job_id="job-lucy21-both", status="pending")
 
         job = await client.queue.submit(
             {
-                "model": models.video("lucy-2"),
+                "model": models.video("lucy-2.1"),
                 "prompt": "Transform the scene",
                 "reference_image": b"fake image data",
                 "data": b"fake video data",
@@ -332,7 +332,7 @@ async def test_queue_lucy2_v2v_with_both_prompt_and_reference_image() -> None:
             }
         )
 
-        assert job.job_id == "job-lucy2-both"
+        assert job.job_id == "job-lucy21-both"
         assert job.status == "pending"
         mock_submit.assert_called_once()
 

--- a/tests/test_realtime_unit.py
+++ b/tests/test_realtime_unit.py
@@ -49,8 +49,8 @@ def test_realtime_models_available():
     model2 = models.realtime("lucy-2.1")
     assert model2.name == "lucy-2.1"
     assert model2.fps == 20
-    assert model2.width == 1280
-    assert model2.height == 720
+    assert model2.width == 1088
+    assert model2.height == 624
     assert model2.url_path == "/v1/stream"
 
 

--- a/tests/test_realtime_unit.py
+++ b/tests/test_realtime_unit.py
@@ -46,8 +46,8 @@ def test_realtime_models_available():
     assert model2.height == 704
     assert model2.url_path == "/v1/stream"
 
-    model2 = models.realtime("lucy-2")
-    assert model2.name == "lucy-2"
+    model2 = models.realtime("lucy-2.1")
+    assert model2.name == "lucy-2.1"
     assert model2.fps == 20
     assert model2.width == 1280
     assert model2.height == 720

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -158,10 +158,10 @@ async def test_create_token_with_allowed_models() -> None:
     )
 
     with patch.object(client, "_get_session", AsyncMock(return_value=mock_session)):
-        await client.tokens.create(allowed_models=["lucy-2"])
+        await client.tokens.create(allowed_models=["lucy-2.1"])
 
     call_kwargs = mock_session.post.call_args
-    assert call_kwargs.kwargs["json"] == {"allowedModels": ["lucy-2"]}
+    assert call_kwargs.kwargs["json"] == {"allowedModels": ["lucy-2.1"]}
 
 
 @pytest.mark.asyncio
@@ -199,7 +199,7 @@ async def test_create_token_with_all_v2_fields() -> None:
         return_value={
             "apiKey": "ek_test123",
             "expiresAt": "2024-12-15T12:10:00Z",
-            "permissions": {"models": ["lucy-2"]},
+            "permissions": {"models": ["lucy-2.1"]},
             "constraints": {"realtime": {"maxSessionDuration": 120}},
         }
     )
@@ -213,19 +213,19 @@ async def test_create_token_with_all_v2_fields() -> None:
         result = await client.tokens.create(
             metadata={"role": "viewer"},
             expires_in=120,
-            allowed_models=["lucy-2"],
+            allowed_models=["lucy-2.1"],
             constraints={"realtime": {"maxSessionDuration": 120}},
         )
 
     assert result.api_key == "ek_test123"
     assert result.expires_at == "2024-12-15T12:10:00Z"
-    assert result.permissions == {"models": ["lucy-2"]}
+    assert result.permissions == {"models": ["lucy-2.1"]}
     assert result.constraints == {"realtime": {"maxSessionDuration": 120}}
 
     call_kwargs = mock_session.post.call_args
     assert call_kwargs.kwargs["json"] == {
         "metadata": {"role": "viewer"},
         "expiresIn": 120,
-        "allowedModels": ["lucy-2"],
+        "allowedModels": ["lucy-2.1"],
         "constraints": {"realtime": {"maxSessionDuration": 120}},
     }


### PR DESCRIPTION
## Summary
- remove `lucy-2` from realtime and video model definitions
- remove retired Lucy 2 SDK aliases (`lucy_2_rt`, `lucy-2-v2v`)
- update examples, playground, and tests to use `lucy-2.1`

## Test plan
- `.venv/bin/python -m pytest tests/test_models.py tests/test_realtime_unit.py`
- `.venv/bin/ruff check .`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily removes deprecated/retired model identifiers and updates references/tests; main risk is a breaking change for users still passing `lucy-2` or its old aliases.
> 
> **Overview**
> Removes retired `lucy-2` model IDs from the SDK’s realtime/video model unions and `_MODELS` registry, and drops legacy alias mappings for `lucy_2_rt` and `lucy-2-v2v`.
> 
> Updates sample code, playground model lists, token docs/examples, and unit tests to use `lucy-2.1` instead (including updated expected model dimensions/FPS and queue submission fixtures).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9410feeeb3af3563a3fe50cc3f5ae3c489a58c5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->