### PR TITLE
feat: scope client tokens to specific browser origins

### DIFF
--- a/decart/tokens/client.py
+++ b/decart/tokens/client.py
@@ -25,10 +25,11 @@ class TokensClient:
         # With metadata:
         token = await client.tokens.create(metadata={"role": "viewer"})
 
-        # With expiry, model restrictions, and constraints:
+        # With expiry, model restrictions, origin restrictions, and constraints:
         token = await client.tokens.create(
             expires_in=120,
             allowed_models=["lucy-2.1"],
+            allowed_origins=["https://example.com"],
             constraints={"realtime": {"maxSessionDuration": 300}},
         )
         ```
@@ -46,6 +47,7 @@ class TokensClient:
         metadata: dict[str, Any] | None = None,
         expires_in: int | None = None,
         allowed_models: list[Union[Model, str]] | None = None,
+        allowed_origins: list[str] | None = None,
         constraints: TokenConstraints | None = None,
     ) -> CreateTokenResponse:
         """
@@ -55,6 +57,11 @@ class TokensClient:
             metadata: Optional custom key-value pairs to attach to the token.
             expires_in: Seconds until the token expires (1-3600, default 60).
             allowed_models: Restrict which models this token can access (max 20).
+            allowed_origins: Restrict which web origins this token can be used
+                from (max 20). Each entry must be a full origin including
+                scheme, e.g. ``https://example.com``. Enforced on realtime
+                sessions by matching the WebSocket ``Origin`` header verbatim.
+                Defense-in-depth — only effective for browser-based clients.
             constraints: Operational limits, e.g.
                 ``{"realtime": {"maxSessionDuration": 120}}``.
 
@@ -71,6 +78,7 @@ class TokensClient:
                 metadata={"role": "viewer"},
                 expires_in=120,
                 allowed_models=["lucy-2.1"],
+                allowed_origins=["https://example.com"],
                 constraints={"realtime": {"maxSessionDuration": 300}},
             )
             ```
@@ -93,6 +101,8 @@ class TokensClient:
             body["expiresIn"] = expires_in
         if allowed_models is not None:
             body["allowedModels"] = list(allowed_models)
+        if allowed_origins is not None:
+            body["allowedOrigins"] = list(allowed_origins)
         if constraints is not None:
             body["constraints"] = constraints
 

--- a/decart/tokens/types.py
+++ b/decart/tokens/types.py
@@ -11,8 +11,9 @@ class TokenConstraints(TypedDict, total=False):
     realtime: RealtimeConstraints
 
 
-class TokenPermissions(TypedDict):
+class TokenPermissions(TypedDict, total=False):
     models: list[str]
+    origins: list[str]
 
 
 class CreateTokenResponse(BaseModel):

--- a/examples/create_token.py
+++ b/examples/create_token.py
@@ -8,11 +8,15 @@ async def main() -> None:
     async with DecartClient(api_key=os.getenv("DECART_API_KEY")) as server_client:
         print("Creating client token...")
 
-        token = await server_client.tokens.create()
+        token = await server_client.tokens.create(
+            allowed_origins=["https://example.com"],
+        )
 
         print("Token created successfully:")
         print(f"  API Key: {token.api_key[:10]}...")
         print(f"  Expires At: {token.expires_at}")
+        origins = (token.permissions or {}).get("origins")
+        print(f"  Allowed Origins: {', '.join(origins) if origins else '(any)'}")
 
         # Client-side: Use the client token
         # In a real app, you would send token.api_key to the frontend

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -165,6 +165,33 @@ async def test_create_token_with_allowed_models() -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_token_with_allowed_origins() -> None:
+    """Sends allowedOrigins in request body."""
+    client = DecartClient(api_key="test-api-key")
+
+    mock_response = AsyncMock()
+    mock_response.ok = True
+    mock_response.json = AsyncMock(
+        return_value={"apiKey": "ek_test123", "expiresAt": "2024-12-15T12:10:00Z"}
+    )
+
+    mock_session = MagicMock()
+    mock_session.post = MagicMock(
+        return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response))
+    )
+
+    with patch.object(client, "_get_session", AsyncMock(return_value=mock_session)):
+        await client.tokens.create(
+            allowed_origins=["https://example.com", "https://app.example.com"]
+        )
+
+    call_kwargs = mock_session.post.call_args
+    assert call_kwargs.kwargs["json"] == {
+        "allowedOrigins": ["https://example.com", "https://app.example.com"]
+    }
+
+
+@pytest.mark.asyncio
 async def test_create_token_with_constraints() -> None:
     """Sends constraints in request body."""
     client = DecartClient(api_key="test-api-key")
@@ -199,7 +226,10 @@ async def test_create_token_with_all_v2_fields() -> None:
         return_value={
             "apiKey": "ek_test123",
             "expiresAt": "2024-12-15T12:10:00Z",
-            "permissions": {"models": ["lucy-2.1"]},
+            "permissions": {
+                "models": ["lucy-2.1"],
+                "origins": ["https://example.com"],
+            },
             "constraints": {"realtime": {"maxSessionDuration": 120}},
         }
     )
@@ -214,12 +244,16 @@ async def test_create_token_with_all_v2_fields() -> None:
             metadata={"role": "viewer"},
             expires_in=120,
             allowed_models=["lucy-2.1"],
+            allowed_origins=["https://example.com"],
             constraints={"realtime": {"maxSessionDuration": 120}},
         )
 
     assert result.api_key == "ek_test123"
     assert result.expires_at == "2024-12-15T12:10:00Z"
-    assert result.permissions == {"models": ["lucy-2.1"]}
+    assert result.permissions == {
+        "models": ["lucy-2.1"],
+        "origins": ["https://example.com"],
+    }
     assert result.constraints == {"realtime": {"maxSessionDuration": 120}}
 
     call_kwargs = mock_session.post.call_args
@@ -227,5 +261,6 @@ async def test_create_token_with_all_v2_fields() -> None:
         "metadata": {"role": "viewer"},
         "expiresIn": 120,
         "allowedModels": ["lucy-2.1"],
+        "allowedOrigins": ["https://example.com"],
         "constraints": {"realtime": {"maxSessionDuration": 120}},
     }

--- a/uv.lock
+++ b/uv.lock
@@ -597,7 +597,7 @@ wheels = [
 
 [[package]]
 name = "decart"
-version = "0.0.33"
+version = "0.0.36"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Adds an `allowed_origins` option to `client.tokens.create()` that scopes a short-lived client token to a specific list of web origins. When the token is later used to open a realtime session, the connection is accepted only if the browser-issued WebSocket `Origin` header matches one of the listed origins.

This complements `allowed_models` to give server-side issuers tighter control over how a frontend-bound token can be used. When omitted, no origin restriction is applied.

## Usage

```python
from decart import DecartClient

async with DecartClient(api_key=os.getenv("DECART_API_KEY")) as server:
    # Token usable only from https://app.example.com
    token = await server.tokens.create(
        allowed_origins=["https://app.example.com"],
        expires_in=60,
    )
```

Combine with the existing options:

```python
token = await server.tokens.create(
    allowed_models=["lucy-2.1"],
    allowed_origins=["https://app.example.com"],
    constraints={"realtime": {"maxSessionDuration": 120}},
)
```

## Notes

- Each entry must be a canonical origin (`scheme://host[:port]`), up to 20 entries.
- Defense-in-depth: enforced via the browser-set `Origin` header, so it raises the cost of stolen-token abuse from a different web origin but does not protect against attackers controlling a non-browser HTTP client.

## Test plan

- [x] `uv run pytest tests/test_tokens.py` — 10/10 pass, including new `allowed_origins` request-body test and updated all-options round-trip.
- [x] `examples/create_token.py` updated to demonstrate the new field.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, additive change that passes a new optional field through to the token-creation API and expands the typed response shape; main risk is mismatched API expectations for the new `allowedOrigins`/`origins` fields.
> 
> **Overview**
> Adds optional `allowed_origins` to `client.tokens.create()` and includes it in the POST body as `allowedOrigins`, allowing server-issued client tokens to be scoped to specific web origins.
> 
> Extends `TokenPermissions` to optionally include `origins`, updates the create-token example to display allowed origins, and adds/updates tests to cover request serialization and permissions round-tripping. Also bumps the package version in `uv.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7de3f4ddb505204a9b0d401bd39c263c0b7050a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->