### PR TITLE
feat: add lucy-vton-3 (realtime + queue/batch)

### DIFF
--- a/decart/models.py
+++ b/decart/models.py
@@ -9,6 +9,7 @@ RealTimeModels = Literal[
     "lucy-2.1",
     "lucy-2.1-vton",
     "lucy-vton-2",
+    "lucy-vton-3",
     "lucy-restyle-2",
     # Latest aliases (server-side resolution)
     "lucy-latest",
@@ -25,6 +26,7 @@ VideoModels = Literal[
     "lucy-2.1",
     "lucy-2.1-vton",
     "lucy-vton-2",
+    "lucy-vton-3",
     "lucy-restyle-2",
     # Latest aliases (server-side resolution)
     "lucy-latest",
@@ -223,6 +225,13 @@ _MODELS = {
             width=1088,
             height=624,
         ),
+        "lucy-vton-3": ModelDefinition(
+            name="lucy-vton-3",
+            url_path="/v1/stream",
+            fps=30,
+            width=1088,
+            height=624,
+        ),
         "lucy-2.1-vton-2": ModelDefinition(
             name="lucy-2.1-vton-2",
             url_path="/v1/stream",
@@ -282,6 +291,14 @@ _MODELS = {
         "lucy-vton-2": ModelDefinition(
             name="lucy-vton-2",
             url_path="/v1/jobs/lucy-vton-2",
+            fps=20,
+            width=1088,
+            height=624,
+            input_schema=VideoEdit2Input,
+        ),
+        "lucy-vton-3": ModelDefinition(
+            name="lucy-vton-3",
+            url_path="/v1/jobs/lucy-vton-3",
             fps=20,
             width=1088,
             height=624,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -24,6 +24,20 @@ def test_canonical_realtime_models() -> None:
     assert model.width == 1088
     assert model.height == 624
 
+    model = models.realtime("lucy-vton-2")
+    assert model.name == "lucy-vton-2"
+    assert model.url_path == "/v1/stream"
+    assert model.fps == 30
+    assert model.width == 1088
+    assert model.height == 624
+
+    model = models.realtime("lucy-vton-3")
+    assert model.name == "lucy-vton-3"
+    assert model.url_path == "/v1/stream"
+    assert model.fps == 30
+    assert model.width == 1088
+    assert model.height == 624
+
 
 def test_deprecated_realtime_models() -> None:
     _warned_aliases.clear()
@@ -52,6 +66,20 @@ def test_canonical_video_models() -> None:
     model = models.video("lucy-2.1-vton")
     assert model.name == "lucy-2.1-vton"
     assert model.url_path == "/v1/jobs/lucy-2.1-vton"
+    assert model.fps == 20
+    assert model.width == 1088
+    assert model.height == 624
+
+    model = models.video("lucy-vton-2")
+    assert model.name == "lucy-vton-2"
+    assert model.url_path == "/v1/jobs/lucy-vton-2"
+    assert model.fps == 20
+    assert model.width == 1088
+    assert model.height == 624
+
+    model = models.video("lucy-vton-3")
+    assert model.name == "lucy-vton-3"
+    assert model.url_path == "/v1/jobs/lucy-vton-3"
     assert model.fps == 20
     assert model.width == 1088
     assert model.height == 624


### PR DESCRIPTION
## What

Adds **`lucy-vton-3`** as a public virtual try-on model, available on both realtime streaming and the queue/batch API. It joins the existing VTON lineup (`lucy-2.1-vton`, `lucy-vton-2`), which all remain supported. `lucy-vton-latest` continues to resolve server-side to the newest VTON.

## Why

Gives users access to the latest virtual try-on generation through the Python SDK, with the same input surface and ergonomics as the previous VTON models — no migration needed to adopt it.

## Usage

```python
from decart import models

# Realtime streaming
rt = models.realtime("lucy-vton-3")

# Queue / batch video try-on
result = await client.queue.submit_and_poll(
    model=models.video("lucy-vton-3"),
    prompt="Wearing a red leather jacket",
    data=video_blob,
)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive model registry and test coverage only; no auth, billing, or behavioral changes to existing models.
> 
> **Overview**
> Registers **`lucy-vton-3`** in the Python SDK model catalog so callers can select it via `models.realtime("lucy-vton-3")` and `models.video("lucy-vton-3")`, alongside the existing VTON models.
> 
> Realtime maps to `/v1/stream` at 30 fps (1088×624), matching other VTON stream models. Queue/batch uses `/v1/jobs/lucy-vton-3` at 20 fps with the same **`VideoEdit2Input`** schema as `lucy-vton-2`. Type literals `RealTimeModels` and `VideoModels` are updated accordingly, and tests assert registry paths and dimensions for `lucy-vton-2` and the new model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a02b98da8158502348732ce9006ef44ed5ff44e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->