### PR TITLE
feat(tokens): expose signed JWT on client token response

### DIFF
--- a/decart/tokens/client.py
+++ b/decart/tokens/client.py
@@ -20,7 +20,7 @@ class TokensClient:
         ```python
         client = DecartClient(api_key=os.getenv("DECART_API_KEY"))
         token = await client.tokens.create()
-        # Returns: CreateTokenResponse(api_key="ek_...", expires_at="...")
+        # Returns: CreateTokenResponse(api_key="ek_...", token="eyJhbGciOiJFZERTQS...", expires_at="...")
 
         # With metadata:
         token = await client.tokens.create(metadata={"role": "viewer"})
@@ -71,7 +71,7 @@ class TokensClient:
         Example:
             ```python
             token = await client.tokens.create()
-            # Returns: CreateTokenResponse(api_key="ek_...", expires_at="...")
+            # Returns: CreateTokenResponse(api_key="ek_...", token="eyJhbGciOiJFZERTQS...", expires_at="...")
 
             # With all options:
             token = await client.tokens.create(
@@ -120,6 +120,7 @@ class TokensClient:
             data = await response.json()
             return CreateTokenResponse(
                 api_key=data["apiKey"],
+                token=data.get("token"),
                 expires_at=data["expiresAt"],
                 permissions=data.get("permissions"),
                 constraints=data.get("constraints"),

--- a/decart/tokens/types.py
+++ b/decart/tokens/types.py
@@ -20,6 +20,8 @@ class CreateTokenResponse(BaseModel):
     """Response from creating a client token."""
 
     api_key: str
+    token: str | None = None
+    """Signed JWT mirroring ``api_key``, verifiable offline via the public JWKS."""
     expires_at: str
     permissions: TokenPermissions | None = None
     constraints: TokenConstraints | None = None

--- a/examples/create_token.py
+++ b/examples/create_token.py
@@ -14,6 +14,7 @@ async def main() -> None:
 
         print("Token created successfully:")
         print(f"  API Key: {token.api_key[:10]}...")
+        print(f"  JWT: {f'{token.token[:16]}...' if token.token else '(not issued)'}")
         print(f"  Expires At: {token.expires_at}")
         origins = (token.permissions or {}).get("origins")
         print(f"  Allowed Origins: {', '.join(origins) if origins else '(any)'}")

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -25,6 +25,7 @@ async def test_create_token() -> None:
         result = await client.tokens.create()
 
     assert result.api_key == "ek_test123"
+    assert result.token is None
     assert result.expires_at == "2024-12-15T12:10:00Z"
     assert result.permissions is None
     assert result.constraints is None
@@ -225,6 +226,7 @@ async def test_create_token_with_all_v2_fields() -> None:
     mock_response.json = AsyncMock(
         return_value={
             "apiKey": "ek_test123",
+            "token": "eyJhbGciOiJFZERTQS123",
             "expiresAt": "2024-12-15T12:10:00Z",
             "permissions": {
                 "models": ["lucy-2.1"],
@@ -249,6 +251,7 @@ async def test_create_token_with_all_v2_fields() -> None:
         )
 
     assert result.api_key == "ek_test123"
+    assert result.token == "eyJhbGciOiJFZERTQS123"
     assert result.expires_at == "2024-12-15T12:10:00Z"
     assert result.permissions == {
         "models": ["lucy-2.1"],


### PR DESCRIPTION
## What

`tokens.create()` now surfaces the server-issued signed JWT as `token`, alongside the existing opaque `api_key`.

## Why

The JWT carries the same authorization context as the opaque key but can be verified offline against the public JWKS, so gateways can authenticate client tokens by signature instead of round-tripping to a verify endpoint on every connection. The opaque `api_key` is unchanged and remains the default; `token` is optional and is simply omitted (`None`) when signing isn't available — so this is fully backward compatible.

## Usage

```python
client = DecartClient(api_key=os.getenv("DECART_API_KEY"))
token = await client.tokens.create()

token.api_key  # "ek_..."                — opaque key (online verify)
token.token    # "eyJhbGciOiJFZERTQS..." — signed JWT (offline JWKS verify), may be None
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive response field with optional parsing only; no request or auth flow changes in the SDK.
> 
> **Overview**
> `tokens.create()` now returns an optional **`token`** on `CreateTokenResponse` — a signed JWT from the API’s `token` field, alongside the unchanged opaque **`api_key`**.
> 
> The client maps `data.get("token")` into the model (defaults to **`None`** when signing isn’t returned), so existing callers stay compatible. Docs and the create-token example note offline JWKS verification; tests cover missing vs present JWT in responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91ae552b2eb211a71a7555de28108a45ed7f3098. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->