### PR TITLE
chore: remove lucy-2.1-vton

### DIFF
--- a/decart/models.py
+++ b/decart/models.py
@@ -7,7 +7,6 @@ from .types import FileInput
 RealTimeModels = Literal[
     # Canonical names
     "lucy-2.1",
-    "lucy-2.1-vton",
     "lucy-vton-2",
     "lucy-vton-3",
     "lucy-restyle-2",
@@ -16,7 +15,6 @@ RealTimeModels = Literal[
     "lucy-vton-latest",
     "lucy-restyle-latest",
     # Deprecated names
-    "lucy-vton",
     "lucy-2.1-vton-2",
     "mirage_v2",
 ]
@@ -24,7 +22,6 @@ VideoModels = Literal[
     # Canonical names
     "lucy-clip",
     "lucy-2.1",
-    "lucy-2.1-vton",
     "lucy-vton-2",
     "lucy-vton-3",
     "lucy-restyle-2",
@@ -34,7 +31,6 @@ VideoModels = Literal[
     "lucy-restyle-latest",
     "lucy-clip-latest",
     # Deprecated / alias names
-    "lucy-vton",
     "lucy-2.1-vton-2",
     "lucy-pro-v2v",
     "lucy-restyle-v2v",
@@ -56,7 +52,6 @@ MODEL_ALIASES: dict[str, str] = {
     "lucy-pro-v2v": "lucy-clip",
     "lucy-restyle-v2v": "lucy-restyle-2",
     # VTON aliases
-    "lucy-vton": "lucy-2.1-vton",
     "lucy-2.1-vton-2": "lucy-vton-2",
     # Image aliases
     "lucy-pro-i2i": "lucy-image-2",
@@ -189,13 +184,6 @@ _MODELS = {
             width=1088,
             height=624,
         ),
-        "lucy-2.1-vton": ModelDefinition(
-            name="lucy-2.1-vton",
-            url_path="/v1/stream",
-            fps=30,
-            width=1088,
-            height=624,
-        ),
         "lucy-restyle-2": ModelDefinition(
             name="lucy-restyle-2",
             url_path="/v1/stream",
@@ -247,13 +235,6 @@ _MODELS = {
             height=704,
         ),
         # Deprecated names
-        "lucy-vton": ModelDefinition(
-            name="lucy-vton",
-            url_path="/v1/stream",
-            fps=30,
-            width=1088,
-            height=624,
-        ),
         "mirage_v2": ModelDefinition(
             name="mirage_v2",
             url_path="/v1/stream",
@@ -280,14 +261,6 @@ _MODELS = {
             height=624,
             input_schema=VideoEdit2Input,
         ),
-        "lucy-2.1-vton": ModelDefinition(
-            name="lucy-2.1-vton",
-            url_path="/v1/jobs/lucy-2.1-vton",
-            fps=20,
-            width=1088,
-            height=624,
-            input_schema=VideoEdit2Input,
-        ),
         "lucy-vton-2": ModelDefinition(
             name="lucy-vton-2",
             url_path="/v1/jobs/lucy-vton-2",
@@ -307,14 +280,6 @@ _MODELS = {
         "lucy-2.1-vton-2": ModelDefinition(
             name="lucy-2.1-vton-2",
             url_path="/v1/jobs/lucy-2.1-vton-2",
-            fps=20,
-            width=1088,
-            height=624,
-            input_schema=VideoEdit2Input,
-        ),
-        "lucy-vton": ModelDefinition(
-            name="lucy-vton",
-            url_path="/v1/jobs/lucy-vton",
             fps=20,
             width=1088,
             height=624,
@@ -430,7 +395,6 @@ class Models:
         Available models:
             - "lucy-clip" - Video-to-video
             - "lucy-2.1" - Video editing (newer, higher quality)
-            - "lucy-2.1-vton" - Virtual try-on video editing
             - "lucy-restyle-2" - Video restyling with prompt or reference image
         """
         _warn_deprecated(model)

--- a/examples/video_tryon.py
+++ b/examples/video_tryon.py
@@ -1,7 +1,7 @@
 """
 Virtual Try-On Example
 
-This example demonstrates how to use the lucy-2.1-vton model to perform
+This example demonstrates how to use the lucy-vton-3 model to perform
 virtual try-on on a video using a reference garment image.
 
 Usage:
@@ -69,7 +69,7 @@ async def main():
 
     async with DecartClient(api_key=api_key) as client:
         options = {
-            "model": models.video("lucy-2.1-vton"),
+            "model": models.video("lucy-vton-3"),
             "data": video_path,
             "prompt": args.prompt,
             "reference_image": ref_path,

--- a/playground/playground.py
+++ b/playground/playground.py
@@ -58,7 +58,7 @@ logging.basicConfig(level=logging.WARNING)
 
 REALTIME_MODELS = [
     "lucy-2.1",
-    "lucy-2.1-vton",
+    "lucy-vton-3",
     "lucy-restyle-2",
 ]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -18,12 +18,6 @@ def test_canonical_realtime_models() -> None:
     assert model.width == 1088
     assert model.height == 624
 
-    model = models.realtime("lucy-2.1-vton")
-    assert model.name == "lucy-2.1-vton"
-    assert model.fps == 30
-    assert model.width == 1088
-    assert model.height == 624
-
     model = models.realtime("lucy-vton-2")
     assert model.name == "lucy-vton-2"
     assert model.url_path == "/v1/stream"
@@ -59,13 +53,6 @@ def test_canonical_video_models() -> None:
     model = models.video("lucy-2.1")
     assert model.name == "lucy-2.1"
     assert model.url_path == "/v1/jobs/lucy-2.1"
-    assert model.fps == 20
-    assert model.width == 1088
-    assert model.height == 624
-
-    model = models.video("lucy-2.1-vton")
-    assert model.name == "lucy-2.1-vton"
-    assert model.url_path == "/v1/jobs/lucy-2.1-vton"
     assert model.fps == 20
     assert model.width == 1088
     assert model.height == 624


### PR DESCRIPTION
## Summary

- Remove `lucy-2.1-vton` and its `lucy-vton` alias from the Python SDK: type literals, `MODEL_ALIASES`, and the realtime/video `_MODELS` registries. `models.realtime()` / `models.video()` now raise `ModelNotFoundError` for these names.
- Keep `lucy-2.1-vton-2` as the supported legacy VTON2 alias (deprecation warning → `lucy-vton-2`), with its existing endpoint path.
- Move the virtual try-on example and the realtime playground VTON option to `lucy-vton-3`.
- Tests: drop the retired `lucy-2.1-vton` assertions only (no added tests).

Mirrors the JS SDK change in DecartAI/sdk#177.

## Validation

- `uv run ruff check` + `uv run black --check` on changed files (clean)
- `uv run pytest tests/test_models.py` (13 passed)
- `uv run pytest` (64 passed, 20 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for any code still passing `lucy-2.1-vton` or `lucy-vton`; behavior is intentional model retirement, not a runtime bug in active paths.
> 
> **Overview**
> **Removes** the retired virtual try-on identifiers `lucy-2.1-vton` and `lucy-vton` from the Python SDK: they are dropped from `RealTimeModels` / `VideoModels`, from `MODEL_ALIASES`, and from the realtime and video `_MODELS` registries (including job/stream paths). Callers using those names will get `ModelNotFoundError` instead of a resolved definition.
> 
> **Keeps** `lucy-2.1-vton-2` as the legacy alias that warns and maps to `lucy-vton-2`. Docs in `models.video()` no longer list `lucy-2.1-vton`.
> 
> **Updates** sample tooling to the current VTON model: `examples/video_tryon.py` and the realtime playground model list use `lucy-vton-3` instead of `lucy-2.1-vton`. Tests drop assertions for the removed models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77974e2e633ac36ff1845fc81c2035440714b1b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->