### PR TITLE
feat(models): add lucy-2.5 model (realtime + batch)

### DIFF
--- a/decart/models.py
+++ b/decart/models.py
@@ -7,6 +7,7 @@ from .types import FileInput
 RealTimeModels = Literal[
     # Canonical names
     "lucy-2.1",
+    "lucy-2.5",
     "lucy-vton-2",
     "lucy-vton-3",
     "lucy-restyle-2",
@@ -22,6 +23,7 @@ VideoModels = Literal[
     # Canonical names
     "lucy-clip",
     "lucy-2.1",
+    "lucy-2.5",
     "lucy-vton-2",
     "lucy-vton-3",
     "lucy-restyle-2",
@@ -184,6 +186,13 @@ _MODELS = {
             width=1088,
             height=624,
         ),
+        "lucy-2.5": ModelDefinition(
+            name="lucy-2.5",
+            url_path="/v1/stream",
+            fps=20,
+            width=1088,
+            height=624,
+        ),
         "lucy-restyle-2": ModelDefinition(
             name="lucy-restyle-2",
             url_path="/v1/stream",
@@ -256,6 +265,14 @@ _MODELS = {
         "lucy-2.1": ModelDefinition(
             name="lucy-2.1",
             url_path="/v1/jobs/lucy-2.1",
+            fps=20,
+            width=1088,
+            height=624,
+            input_schema=VideoEdit2Input,
+        ),
+        "lucy-2.5": ModelDefinition(
+            name="lucy-2.5",
+            url_path="/v1/jobs/lucy-2.5",
             fps=20,
             width=1088,
             height=624,
@@ -395,6 +412,7 @@ class Models:
         Available models:
             - "lucy-clip" - Video-to-video
             - "lucy-2.1" - Video editing (newer, higher quality)
+            - "lucy-2.5" - Video editing (latest generation)
             - "lucy-restyle-2" - Video restyling with prompt or reference image
         """
         _warn_deprecated(model)

--- a/playground/playground.py
+++ b/playground/playground.py
@@ -58,6 +58,7 @@ logging.basicConfig(level=logging.WARNING)
 
 REALTIME_MODELS = [
     "lucy-2.1",
+    "lucy-2.5",
     "lucy-vton-3",
     "lucy-restyle-2",
 ]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -18,6 +18,13 @@ def test_canonical_realtime_models() -> None:
     assert model.width == 1088
     assert model.height == 624
 
+    model = models.realtime("lucy-2.5")
+    assert model.name == "lucy-2.5"
+    assert model.url_path == "/v1/stream"
+    assert model.fps == 20
+    assert model.width == 1088
+    assert model.height == 624
+
     model = models.realtime("lucy-vton-2")
     assert model.name == "lucy-vton-2"
     assert model.url_path == "/v1/stream"
@@ -53,6 +60,13 @@ def test_canonical_video_models() -> None:
     model = models.video("lucy-2.1")
     assert model.name == "lucy-2.1"
     assert model.url_path == "/v1/jobs/lucy-2.1"
+    assert model.fps == 20
+    assert model.width == 1088
+    assert model.height == 624
+
+    model = models.video("lucy-2.5")
+    assert model.name == "lucy-2.5"
+    assert model.url_path == "/v1/jobs/lucy-2.5"
     assert model.fps == 20
     assert model.width == 1088
     assert model.height == 624


### PR DESCRIPTION
Makes Decart's latest Lucy generation, **lucy-2.5**, available to Python SDK users for both realtime streaming and batch/queue video editing. This brings the Python SDK to parity with the other SDKs and lets users adopt the newest model without waiting on a client update.

`lucy-2.5` is a canonical model (no deprecation aliases) supporting video editing with an optional reference image — the same input shape as `lucy-2.1`.

Usage:

```python
from decart import DecartClient, models

client = DecartClient(api_key="...")

# Batch / queue
result = await client.queue.submit_and_poll({
    "model": models.video("lucy-2.5"),
    "prompt": "Watercolor painting style with soft brushstrokes",
    "data": video_file,
})

# Realtime
connection = await client.realtime.connect(
    model=models.realtime("lucy-2.5"),
    ...
)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive model registry and test coverage only; no changes to auth, request handling, or existing model behavior.
> 
> **Overview**
> Adds **`lucy-2.5`** as a canonical model for both **realtime streaming** and **queue/batch video editing**, matching the pattern used for `lucy-2.1`.
> 
> Realtime uses `/v1/stream` at **20 fps** and **1088×624** (vs 30 fps for `lucy-2.1`). Batch jobs use `/v1/jobs/lucy-2.5` with the same **`VideoEdit2Input`** shape (prompt + optional reference image). The playground CLI model list and model registry tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6618cea726d78bf9a103bf926a0a3a4d3e5548c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->