### PR TITLE
fix(models): correct lucy-2.5 resolution (720p) and realtime fps

### DIFF
--- a/decart/models.py
+++ b/decart/models.py
@@ -189,9 +189,9 @@ _MODELS = {
         "lucy-2.5": ModelDefinition(
             name="lucy-2.5",
             url_path="/v1/stream",
-            fps=20,
-            width=1088,
-            height=624,
+            fps=30,
+            width=1280,
+            height=720,
         ),
         "lucy-restyle-2": ModelDefinition(
             name="lucy-restyle-2",
@@ -274,8 +274,8 @@ _MODELS = {
             name="lucy-2.5",
             url_path="/v1/jobs/lucy-2.5",
             fps=20,
-            width=1088,
-            height=624,
+            width=1280,
+            height=720,
             input_schema=VideoEdit2Input,
         ),
         "lucy-vton-2": ModelDefinition(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -21,9 +21,9 @@ def test_canonical_realtime_models() -> None:
     model = models.realtime("lucy-2.5")
     assert model.name == "lucy-2.5"
     assert model.url_path == "/v1/stream"
-    assert model.fps == 20
-    assert model.width == 1088
-    assert model.height == 624
+    assert model.fps == 30
+    assert model.width == 1280
+    assert model.height == 720
 
     model = models.realtime("lucy-vton-2")
     assert model.name == "lucy-vton-2"
@@ -68,8 +68,8 @@ def test_canonical_video_models() -> None:
     assert model.name == "lucy-2.5"
     assert model.url_path == "/v1/jobs/lucy-2.5"
     assert model.fps == 20
-    assert model.width == 1088
-    assert model.height == 624
+    assert model.width == 1280
+    assert model.height == 720
 
     model = models.video("lucy-vton-2")
     assert model.name == "lucy-vton-2"


### PR DESCRIPTION
## What

Corrects the `lucy-2.5` model metadata so it reflects the model's actual output. It now reports **1280×720** for both realtime and video, and realtime runs at **30fps** (video stays at 20fps).

## Why

`lucy-2.5` is a 720p, 30fps-realtime model, but the SDK was reporting the older Lucy sizing (1088×624) and a 20fps realtime rate. Anyone reading these values — or relying on them to size their capture/render pipeline — was getting the wrong resolution and frame rate.

## Usage

```python
from decart import models

rt = models.realtime("lucy-2.5")
# rt.width == 1280, rt.height == 720, rt.fps == 30

vid = models.video("lucy-2.5")
# vid.width == 1280, vid.height == 720, vid.fps == 20
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only registry and test changes; realtime fps alignment may change LiveKit timing for existing `lucy-2.5` integrations that relied on the old 20fps value.
> 
> **Overview**
> Updates **`lucy-2.5`** registry metadata so it matches the model’s real output instead of legacy Lucy 2.1 sizing.
> 
> For **realtime** (`models.realtime("lucy-2.5")`), **fps** goes from 20 → **30** and dimensions from 1088×624 → **1280×720**. For **video** jobs (`models.video("lucy-2.5")`), only resolution changes to **1280×720**; job **fps** stays at 20.
> 
> Tests in `test_models.py` are updated to assert the new values. Because the realtime client wires `model.fps` into LiveKit, this also corrects frame-rate configuration for `lucy-2.5` streams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8756e6ee74ba16eb02a2b7220e314643b690eac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->