### PR TITLE
Remove the deprecated mirage_v2 alias

### DIFF
--- a/decart/models.py
+++ b/decart/models.py
@@ -17,7 +17,6 @@ RealTimeModels = Literal[
     "lucy-restyle-latest",
     # Deprecated names
     "lucy-2.1-vton-2",
-    "mirage_v2",
 ]
 VideoModels = Literal[
     # Canonical names
@@ -48,8 +47,6 @@ ImageModels = Literal[
 Model = Literal[RealTimeModels, VideoModels, ImageModels]
 
 MODEL_ALIASES: dict[str, str] = {
-    # Realtime aliases
-    "mirage_v2": "lucy-restyle-2",
     # Video aliases
     "lucy-pro-v2v": "lucy-clip",
     "lucy-restyle-v2v": "lucy-restyle-2",
@@ -238,14 +235,6 @@ _MODELS = {
         ),
         "lucy-restyle-latest": ModelDefinition(
             name="lucy-restyle-latest",
-            url_path="/v1/stream",
-            fps=30,
-            width=1280,
-            height=704,
-        ),
-        # Deprecated names
-        "mirage_v2": ModelDefinition(
-            name="mirage_v2",
             url_path="/v1/stream",
             fps=30,
             width=1280,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -45,11 +45,11 @@ def test_deprecated_realtime_models() -> None:
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        model = models.realtime("mirage_v2")
-        assert model.name == "mirage_v2"
+        model = models.realtime("lucy-2.1-vton-2")
+        assert model.name == "lucy-2.1-vton-2"
         assert len(w) == 1
         assert "deprecated" in str(w[0].message).lower()
-        assert "lucy-restyle-2" in str(w[0].message)
+        assert "lucy-vton-2" in str(w[0].message)
 
 
 def test_canonical_video_models() -> None:
@@ -132,9 +132,9 @@ def test_deprecation_warning_only_once() -> None:
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        models.realtime("mirage_v2")
-        models.realtime("mirage_v2")
-        models.realtime("mirage_v2")
+        models.realtime("lucy-2.1-vton-2")
+        models.realtime("lucy-2.1-vton-2")
+        models.realtime("lucy-2.1-vton-2")
         assert len(w) == 1
 
 


### PR DESCRIPTION
mirage_v2 aliased lucy-restyle-2. Removes it from RealTimeModels, MODEL_ALIASES and _MODELS; repoints the affected unittests to lucy-2.1-vton-2. Breaking: models.realtime('mirage_v2') now raises ModelNotFoundError.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Intentional breaking API change: any integration still passing `mirage_v2` to `models.realtime()` will fail at runtime.
> 
> **Overview**
> Removes the deprecated **`mirage_v2`** realtime model name, which previously aliased **`lucy-restyle-2`**. It is dropped from **`RealTimeModels`**, **`MODEL_ALIASES`**, and the realtime **`_MODELS`** registry.
> 
> **Breaking:** `models.realtime("mirage_v2")` no longer resolves and will raise **`ModelNotFoundError`**. Callers should use **`lucy-restyle-2`** (or another supported realtime name).
> 
> Deprecation-related tests now use **`lucy-2.1-vton-2`** → **`lucy-vton-2`** instead of **`mirage_v2`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2c2e45e16f7080e3decdd6cf1b0ce2688cf8ab0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->