### PR TITLE
feat(models): add lucy-vton-3.5 (realtime + batch)

### DIFF
--- a/decart/models.py
+++ b/decart/models.py
@@ -10,6 +10,7 @@ RealTimeModels = Literal[
     "lucy-2.5",
     "lucy-vton-2",
     "lucy-vton-3",
+    "lucy-vton-3.5",
     "lucy-restyle-2",
     # Latest aliases (server-side resolution)
     "lucy-latest",
@@ -25,6 +26,7 @@ VideoModels = Literal[
     "lucy-2.5",
     "lucy-vton-2",
     "lucy-vton-3",
+    "lucy-vton-3.5",
     "lucy-restyle-2",
     # Latest aliases (server-side resolution)
     "lucy-latest",
@@ -226,6 +228,13 @@ _MODELS = {
             width=1088,
             height=624,
         ),
+        "lucy-vton-3.5": ModelDefinition(
+            name="lucy-vton-3.5",
+            url_path="/v1/stream",
+            fps=30,
+            width=1088,
+            height=624,
+        ),
         "lucy-2.1-vton-2": ModelDefinition(
             name="lucy-2.1-vton-2",
             url_path="/v1/stream",
@@ -278,6 +287,14 @@ _MODELS = {
         "lucy-vton-3": ModelDefinition(
             name="lucy-vton-3",
             url_path="/v1/jobs/lucy-vton-3",
+            fps=20,
+            width=1088,
+            height=624,
+            input_schema=VideoEdit2Input,
+        ),
+        "lucy-vton-3.5": ModelDefinition(
+            name="lucy-vton-3.5",
+            url_path="/v1/jobs/lucy-vton-3.5",
             fps=20,
             width=1088,
             height=624,

--- a/playground/playground.py
+++ b/playground/playground.py
@@ -60,6 +60,7 @@ REALTIME_MODELS = [
     "lucy-2.1",
     "lucy-2.5",
     "lucy-vton-3",
+    "lucy-vton-3.5",
     "lucy-restyle-2",
 ]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -39,6 +39,13 @@ def test_canonical_realtime_models() -> None:
     assert model.width == 1088
     assert model.height == 624
 
+    model = models.realtime("lucy-vton-3.5")
+    assert model.name == "lucy-vton-3.5"
+    assert model.url_path == "/v1/stream"
+    assert model.fps == 30
+    assert model.width == 1088
+    assert model.height == 624
+
 
 def test_deprecated_realtime_models() -> None:
     _warned_aliases.clear()
@@ -81,6 +88,13 @@ def test_canonical_video_models() -> None:
     model = models.video("lucy-vton-3")
     assert model.name == "lucy-vton-3"
     assert model.url_path == "/v1/jobs/lucy-vton-3"
+    assert model.fps == 20
+    assert model.width == 1088
+    assert model.height == 624
+
+    model = models.video("lucy-vton-3.5")
+    assert model.name == "lucy-vton-3.5"
+    assert model.url_path == "/v1/jobs/lucy-vton-3.5"
     assert model.fps == 20
     assert model.width == 1088
     assert model.height == 624


### PR DESCRIPTION
Adds the `lucy-vton-3.5` virtual try-on model so SDK users can select the latest VTON generation for both realtime streaming and batch video jobs. It's exposed everywhere the other canonical models are, so it's usable the same way with no new API surface to learn.

## Usage

```python
from decart import models

# Realtime streaming
rt = models.realtime("lucy-vton-3.5")

# Batch video job
video = models.video("lucy-vton-3.5")
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive model registration with no changes to auth, billing, or existing model behavior; risk is mainly that backend endpoints must exist for the new paths.
> 
> **Overview**
> Registers **`lucy-vton-3.5`** as a first-class VTON model for realtime streaming and batch video jobs, mirroring **`lucy-vton-3`** (same resolution and FPS; batch jobs use **`VideoEdit2Input`** and **`/v1/jobs/lucy-vton-3.5`**).
> 
> The name is added to **`RealTimeModels`** / **`VideoModels`**, the internal **`_MODELS`** registry, the playground **`REALTIME_MODELS`** picker, and model tests so **`models.realtime("lucy-vton-3.5")`** and **`models.video("lucy-vton-3.5")`** work like existing canonical models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56bdbc77a7e14c45df6517a6677e8e9c198b22ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->