### PR TITLE
Revert "feat(models): add lucy-vton-3.5 (realtime + batch) (#62)"

### DIFF
--- a/decart/models.py
+++ b/decart/models.py
@@ -10,7 +10,6 @@ RealTimeModels = Literal[
     "lucy-2.5",
     "lucy-vton-2",
     "lucy-vton-3",
-    "lucy-vton-3.5",
     "lucy-restyle-2",
     # Latest aliases (server-side resolution)
     "lucy-latest",
@@ -26,7 +25,6 @@ VideoModels = Literal[
     "lucy-2.5",
     "lucy-vton-2",
     "lucy-vton-3",
-    "lucy-vton-3.5",
     "lucy-restyle-2",
     # Latest aliases (server-side resolution)
     "lucy-latest",
@@ -228,13 +226,6 @@ _MODELS = {
             width=1088,
             height=624,
         ),
-        "lucy-vton-3.5": ModelDefinition(
-            name="lucy-vton-3.5",
-            url_path="/v1/stream",
-            fps=30,
-            width=1088,
-            height=624,
-        ),
         "lucy-2.1-vton-2": ModelDefinition(
             name="lucy-2.1-vton-2",
             url_path="/v1/stream",
@@ -287,14 +278,6 @@ _MODELS = {
         "lucy-vton-3": ModelDefinition(
             name="lucy-vton-3",
             url_path="/v1/jobs/lucy-vton-3",
-            fps=20,
-            width=1088,
-            height=624,
-            input_schema=VideoEdit2Input,
-        ),
-        "lucy-vton-3.5": ModelDefinition(
-            name="lucy-vton-3.5",
-            url_path="/v1/jobs/lucy-vton-3.5",
             fps=20,
             width=1088,
             height=624,

--- a/playground/playground.py
+++ b/playground/playground.py
@@ -60,7 +60,6 @@ REALTIME_MODELS = [
     "lucy-2.1",
     "lucy-2.5",
     "lucy-vton-3",
-    "lucy-vton-3.5",
     "lucy-restyle-2",
 ]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -39,13 +39,6 @@ def test_canonical_realtime_models() -> None:
     assert model.width == 1088
     assert model.height == 624
 
-    model = models.realtime("lucy-vton-3.5")
-    assert model.name == "lucy-vton-3.5"
-    assert model.url_path == "/v1/stream"
-    assert model.fps == 30
-    assert model.width == 1088
-    assert model.height == 624
-
 
 def test_deprecated_realtime_models() -> None:
     _warned_aliases.clear()
@@ -88,13 +81,6 @@ def test_canonical_video_models() -> None:
     model = models.video("lucy-vton-3")
     assert model.name == "lucy-vton-3"
     assert model.url_path == "/v1/jobs/lucy-vton-3"
-    assert model.fps == 20
-    assert model.width == 1088
-    assert model.height == 624
-
-    model = models.video("lucy-vton-3.5")
-    assert model.name == "lucy-vton-3.5"
-    assert model.url_path == "/v1/jobs/lucy-vton-3.5"
     assert model.fps == 20
     assert model.width == 1088
     assert model.height == 624


### PR DESCRIPTION
Reverts DecartAI/decart-python#62.

lucy-vton-3.5 is being rolled back from the SDK. This cleanly reverts the merged squash commit that added the realtime + batch models, types, and tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for any code or docs still targeting `lucy-vton-3.5`; scope is limited to model registry removal with no auth or data-path changes.
> 
> **Overview**
> **Removes `lucy-vton-3.5`** from the Python SDK, reversing the prior addition of that model for realtime streaming and batch video jobs.
> 
> The change drops `lucy-vton-3.5` from the `RealTimeModels` and `VideoModels` type literals, deletes its entries in the realtime and video model registries (stream and `/v1/jobs/lucy-vton-3.5`), removes it from the playground’s realtime model picker, and deletes the associated model tests. Callers that still pass `lucy-vton-3.5` will hit `ModelNotFoundError` instead of resolving a definition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7e11baa21a81a71570d5e749e0b98cef164795e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->